### PR TITLE
Do not write formatted content if it's the same as before

### DIFF
--- a/format/src/main/java/com/spotify/format/Main.java
+++ b/format/src/main/java/com/spotify/format/Main.java
@@ -162,27 +162,27 @@ public final class Main {
       final FormattingResult formattingResult,
       final boolean verify,
       final Set<Path> malformedPaths) {
-      // Use hashing to avoid loading the file into memory... We should probably also do this for
-      // FormattingResult to be fair.
-      final HashCode oldHash;
-      try {
-        oldHash = MoreFiles.asByteSource(formattingResult.path()).hash(Hashing.sha256());
-      } catch (final IOException e) {
-        throw new UncheckedIOException("Could not hash contents of " + formattingResult.path(), e);
-      }
-      final HashCode newHash =
-          Hashing.sha256().hashBytes(formattingResult.contents().getBytes(StandardCharsets.UTF_8));
-      if (!oldHash.equals(newHash)) {
-        if (verify) {
-          malformedPaths.add(formattingResult.path());
-        } else {
-          try {
-            Files.write(formattingResult.path(), formattingResult.contents().getBytes(UTF_8));
-          } catch (final IOException e) {
-            throw new UncheckedIOException("Could not write file " + formattingResult.path(), e);
-          }
+    // Use hashing to avoid loading the file into memory... We should probably also do this for
+    // FormattingResult to be fair.
+    final HashCode oldHash;
+    try {
+      oldHash = MoreFiles.asByteSource(formattingResult.path()).hash(Hashing.sha256());
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Could not hash contents of " + formattingResult.path(), e);
+    }
+    final HashCode newHash =
+        Hashing.sha256().hashBytes(formattingResult.contents().getBytes(StandardCharsets.UTF_8));
+    if (!oldHash.equals(newHash)) {
+      if (verify) {
+        malformedPaths.add(formattingResult.path());
+      } else {
+        try {
+          Files.write(formattingResult.path(), formattingResult.contents().getBytes(UTF_8));
+        } catch (final IOException e) {
+          throw new UncheckedIOException("Could not write file " + formattingResult.path(), e);
         }
       }
+    }
   }
 
   private static FormattingResult formatBuildFile(final Path buildifier, final Path buildFile) {


### PR DESCRIPTION
Intellij goes crazy when 'Last Modified' file timestamp changes for every source file in project. To prevent reimporting Bazel project after format run let's write file only when it content differs after formatting.